### PR TITLE
Added missing type and composer installers to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,7 @@
 {
     "name": "stefanvangastel/feedback-it",
     "description": "Feedback or bugreport (with screenshot!) tab option in your CakePHP application. Data can be posted directly to Mantis, E-mail, Github issues, filesystem, etc.",
+    "type": "cakephp-plugin",
     "authors": [
         {
             "name": "Stefan van Gastel",
@@ -8,6 +9,6 @@
         }
     ],
     "require": {
-
+        "composer/installers": "*"
     }
 }


### PR DESCRIPTION
So I jumped the gun a bit yesterday forgetting to add these 2 things, line 4 tells composer that this package is a CakePHP plugin and line 12 ensures that when installing with composer it is handled as such.
